### PR TITLE
added umami self-host analytics tool

### DIFF
--- a/makefile
+++ b/makefile
@@ -5,7 +5,7 @@ DOCKERHUB_USERNAME := hikariai
 GHCR_USERNAME := yqlbu
 IMAGE_NAME := hikariai-web
 IMAGE_TAG := latest
-DOMAIN_NAME := www.hikariai.net
+DOMAIN_NAME := hikariai.net
 ENV := prod
 SERVER_IP := 10.10.10.50
 
@@ -30,7 +30,7 @@ build-staging:
 		-t $(DOCKERHUB_USERNAME)/$(IMAGE_NAME):$(IMAGE_TAG) \
 		--build-arg ENV=$(ENV) \
 		--build-arg SERVER_IP=$(SERVER_IP) \
-		--build-arg DOMAIN_NAME=$(DOMAIN_NAME) \
+		--build-arg DOMAIN_NAME=staging.$(DOMAIN_NAME) \
 		.
 	@docker tag $(DOCKERHUB_USERNAME)/$(IMAGE_NAME):$(IMAGE_TAG) $(DOCKERHUB_USERNAME)/$(IMAGE_NAME):staging
 
@@ -39,7 +39,7 @@ build-prod:
 		-t $(DOCKERHUB_USERNAME)/$(IMAGE_NAME):$(IMAGE_TAG) \
 		--build-arg ENV=$(ENV) \
 		--build-arg SERVER_IP=$(SERVER_IP) \
-		--build-arg DOMAIN_NAME=$(DOMAIN_NAME) \
+		--build-arg DOMAIN_NAME=www.$(DOMAIN_NAME) \
 		.
 	@docker tag $(DOCKERHUB_USERNAME)/$(IMAGE_NAME):$(IMAGE_TAG) $(DOCKERHUB_USERNAME)/$(IMAGE_NAME):prod
 

--- a/web/layouts/partials/head.html
+++ b/web/layouts/partials/head.html
@@ -24,13 +24,9 @@
     <script type="text/javascript" src="{{ . | absURL }}"></script>
   {{- end }}
 
-  <!-- Open Graph -->
-  <!-- {{ template "_internal/opengraph.html" . }} -->
-  <!-- {{ template "_internal/twitter_cards.html" . }} -->
-
   <!-- Social Media -->
   {{ partial "social_metadata.html" . }}
 
   <!-- Umami Analytices -->
-  <script async defer data-website-id="79f743c6-56d3-4c56-b72d-3f37c8547ab8" src="https://analytics.hikariai.net/umami.js"></script>
+  <script async defer data-website-id="79f743c6-56d3-4c56-b72d-3f37c8547ab8" src="https://umami-hikariai-selfhost.herokuapp.com/umami.js"></script>
 </head>

--- a/web/layouts/partials/head.html
+++ b/web/layouts/partials/head.html
@@ -31,7 +31,6 @@
   <!-- Social Media -->
   {{ partial "social_metadata.html" . }}
 
-  <!-- Google Analytices -->
-  {{ template "_internal/google_analytics.html" . }}
-  {{ template "_internal/google_analytics_async.html" . }}
+  <!-- Umami Analytices -->
+  <script async defer data-website-id="79f743c6-56d3-4c56-b72d-3f37c8547ab8" src="https://analytics.hikariai.net/umami.js"></script>
 </head>


### PR DESCRIPTION
### Summary

Added `Umami` self-hosted analytics solution

### Description

Followed by instructions at https://umami.is/docs/running-on-heroku

### Details

- [x] Added Umami Analytics to `<head>`

### References

https://umami.is/docs/running-on-heroku

### Checks

- [x] Already tested changes in `staging` environment
