### PR TITLE
fixed stats url endpoint

### DIFF
--- a/web/layouts/partials/footer.html
+++ b/web/layouts/partials/footer.html
@@ -23,8 +23,8 @@
       </div>
       <div class="col-lg-12 text-center mt-5">
         <div class="web-stats">
-          <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
-          <script async src="//busuanzi.ibruce.info/busuanzi/2.3/busuanzi.pure.mini.js"></script>
+          <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
+          <script async src="https://busuanzi.ibruce.info/busuanzi/2.3/busuanzi.pure.mini.js"></script>
           <div class="web-stats-col">
             <span><i class="fa fa-user"></i> Total Visitors</span>
             <span id="busuanzi_value_site_uv"></span>

--- a/web/themes/bookworm-light/assets/scss/_common.scss
+++ b/web/themes/bookworm-light/assets/scss/_common.scss
@@ -44,6 +44,7 @@ mark {
 
   &-sm {
     padding: 90px 0;
+    padding-top: 30px;
   }
 }
 
@@ -664,6 +665,29 @@ footer {
       text-decoration: underline;
     }
   }
+}
+.web-stats {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  margin-bottom: 60px;
+  font-size: 20px;
+  color: rgba($white, .7);
+}
+.web-stats-col {
+  display: flex;
+  flex-direction: column;
+}
+.web-stats-col > span:first-of-type {
+  margin-bottom: 10px;
+}
+.web-stats-col > span > i{
+  margin-right: 5px;
+}
+.web-stats-col:first-of-type {
+  margin-right: 100px;
 }
 .copyright-text {
   color: rgba($white, .7);


### PR DESCRIPTION
### Summary

Introduce `web-stats` calculator to the site.

### Details

- [x] added `web-stats` to the footer 
- [x] fixed `web-stats` endpoint url - should use `https` instead 

### References

- https://fuckcloudnative.io/posts/what-happens-when-k8s/
- http://busuanzi.ibruce.info/
- https://www.cnblogs.com/brady-wang/p/13837812.html

### Checks

- [x] Already tested changes in `staging` environment